### PR TITLE
Pass through incoming cookies

### DIFF
--- a/index.js
+++ b/index.js
@@ -88,15 +88,16 @@ const responseHeadersToRemove = ["Accept-Ranges", "Content-Length", "Keep-Alive"
                         ctx.cookies.set(cookie.name, cookie.value, options);
                     });
                 await page.close();
+
+                responseHeadersToRemove.forEach(header => delete responseHeaders[header]);
+                Object.keys(responseHeaders).forEach(header => ctx.set(header, jsesc(responseHeaders[header])));
+                ctx.body = responseBody;
             } catch (error) {
                 if (!error.toString().includes("ERR_BLOCKED_BY_CLIENT")) {
                     ctx.status = 500;
                     ctx.body = error;
                 }
             }
-            responseHeadersToRemove.forEach(header => delete responseHeaders[header]);
-            Object.keys(responseHeaders).forEach(header => ctx.set(header, jsesc(responseHeaders[header])));
-            ctx.body = responseBody;
         }
         else {
             ctx.body = "Please specify the URL in the 'url' query string.";

--- a/index.js
+++ b/index.js
@@ -6,6 +6,7 @@ const bodyParser = require('koa-bodyparser');
 const app = new Koa();
 app.use(bodyParser());
 const jsesc = require('jsesc');
+const tough_cookie = require('tough-cookie');
 
 const headersToRemove = [
     "host", "user-agent", "accept", "accept-encoding", "content-length",

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "koa-bodyparser": "^4.3.0",
     "puppeteer": "^5.2.1",
     "puppeteer-extra": "^3.1.15",
-    "puppeteer-extra-plugin-stealth": "^2.6.1"
+    "puppeteer-extra-plugin-stealth": "^2.6.1",
+    "tough-cookie": "^4.0.0"
   }
 }


### PR DESCRIPTION
This adds support for copying cookies from the incoming request to the underlying browser. This is useful when using a cookie jar copied from another browser for scraping.

Also adds a couple of environment variables for customizing browser behavior: you can set a proxy and disable headless mode.